### PR TITLE
Update fqdn-policy.yaml

### DIFF
--- a/charts/certificator/templates/fqdn-policy.yaml
+++ b/charts/certificator/templates/fqdn-policy.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     team: nais
   name: {{ .Release.Name }}-fqdn
+  annotations:
+    fqdnnetworkpolicies.networking.gke.io/aaaa-lookups: skip
 spec:
   egress:
   - ports:


### PR DESCRIPTION
add annotations to skip AAAA lookup